### PR TITLE
Bugfix: Add whitespace between number of Points and string Point on c…

### DIFF
--- a/lib/view/WpProQuiz_View_FrontQuiz.php
+++ b/lib/view/WpProQuiz_View_FrontQuiz.php
@@ -1021,7 +1021,7 @@ class WpProQuiz_View_FrontQuiz extends WpProQuiz_View_View
 										<?php _e('Correct', 'wp-pro-quiz'); ?>
 									</span>
                                             <span
-                                                style="float: right;"><?php echo $question->getPoints() . ' / ' . $question->getPoints(); ?><?php _e('Points',
+                                                style="float: right;"><?php echo $question->getPoints() . ' / ' . $question->getPoints(); ?> <?php _e('Points',
                                                     'wp-pro-quiz'); ?></span>
 
                                             <div style="clear: both;"></div>


### PR DESCRIPTION
…orrect answer. It is correct for incorrect answers

There was whitespace missing between Number of Points and the string "Points" like it is for incorrect answers. See code for reference.