### PR TITLE
Ensure that Google style is enqueued in an SSL-friendly way.

### DIFF
--- a/lib/controller/WpProQuiz_Controller_Admin.php
+++ b/lib/controller/WpProQuiz_Controller_Admin.php
@@ -77,7 +77,7 @@ class WpProQuiz_Controller_Admin
         );
 
         wp_enqueue_style('jquery-ui',
-            'http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/smoothness/jquery-ui.css');
+            set_url_scheme( 'http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/smoothness/jquery-ui.css' ) );
 
         $this->localizeScript();
     }


### PR DESCRIPTION
It's against wordpress.org repository rules to load a stylesheet from Google like this :) But if you're going to do it, please do it in an SSL-compatible way. Thanks!