### PR TITLE
Remove curly braces from Wp-Pro-Quiz (PHP8)

### DIFF
--- a/lib/helper/WpProQuiz_Helper_Upgrade.php
+++ b/lib/helper/WpProQuiz_Helper_Upgrade.php
@@ -66,7 +66,7 @@ class WpProQuiz_Helper_Upgrade
         //ACHIEVEMENTS Version 2.x.x
         if (defined('ACHIEVEMENTS_IS_INSTALLED') && ACHIEVEMENTS_IS_INSTALLED === 1 && defined('ACHIEVEMENTS_VERSION')) {
             $version = ACHIEVEMENTS_VERSION;
-            if ($version{0} == '2') {
+            if ($version[0] == '2') {
                 WpProQuiz_Plugin_BpAchievementsV2::install();
             }
         }


### PR DESCRIPTION
In PHP8 isn't allowed to use curly braces anymore.

I will go through the code and start a migration path to get this really cool quiz to PHP8.